### PR TITLE
電話番号が空のときは<a>タグを表示しないようにしました

### DIFF
--- a/modals.html
+++ b/modals.html
@@ -52,7 +52,7 @@
                         <button class="btn btn-primary col-1 p-0 mr-2" id="sns_facebook" onclick="Takeaway.opensite($('#osmid').html(),'facebook')">
                             <i class="fab fa-facebook-f"></i>
                         </button>
-                        <div class="col-6 p-1"><a id="phone"><span id="phone_view"></span></a></div>
+                        <div class="col-6 p-1"><span id="phone"></span></div>
                     </div>
                     <div class="row mb-1 align-items-center">
                         <div class="col-2 p-1 text-break" glot-model="modal_opening_hours"></div>

--- a/takeaway.js
+++ b/takeaway.js
@@ -222,9 +222,12 @@ var Takeaway = (function () {
                 delname = delname == undefined ? "?" : delname;
             }
             $("#delivery").html(delname);
-
-            $("#phone").attr('href', tags.phone == null ? "" : "tel:" + tags.phone);
-            $("#phone_view").html(tags.phone == null ? "-" : tags.phone);
+            
+            if (tags.phone != null) {
+                $("#phone").html("<a href=\"" + ("tel:" + tags.phone) + "\">" + tags.phone + "</a>");
+            } else {
+                $("#phone").html("-");
+            }
 
             let fld = {};
             fld.website = tags["contact:website"] == null ? tags["website"] : tags["contact:website"];


### PR DESCRIPTION
電話番号が空のときに href="tel:" のリンクが表示されるのを抑制するようにしました。