### PR TITLE
correct spell

### DIFF
--- a/data/category-en.json
+++ b/data/category-en.json
@@ -32,7 +32,7 @@
             "ice_cream": "ice cream",
             "pasta": "pasta",
             "pastry": "pastry",
-            "seafood": "eafood",
+            "seafood": "seafood",
             "spices": "spices",
             "tea": "tea",
             "water": "water",


### PR DESCRIPTION
`eafood` --> `seafood`