### PR TITLE
テーブルおよび詳細ダイアログに支店名 (branch) を表示

### DIFF
--- a/takeaway.js
+++ b/takeaway.js
@@ -156,7 +156,11 @@ var Takeaway = (function () {
 
             $("#osmid").html(tags.id);
             $("#timestamp").html(date.format("YYYY/MM/DD hh:mm"));
-            $("#name").html(tags.name == null ? "-" : tags.name);
+            let name = tags.name == null ? "" : tags.name;
+            if (tags.branch) {
+                name += " " + tags.branch;
+            }
+            $("#name").html(name == null ? "-" : name);
             $("#category-icon").attr("src", tags.takeaway_icon);
             $("#category").html(PoiCont.get_catname(tags));
 

--- a/takeawayLib.js
+++ b/takeawayLib.js
@@ -43,7 +43,9 @@ var PoiCont = (function () {
                 let tags = node.properties;
                 let _7DaysAgo = new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 7);                //更新一週間以内のデータには印を付加する
                 let update = "<span class='text-danger'>" + glot.get("list_update") + "</span>";
-                let name = tags.name == undefined ? "-" : tags.name + (_7DaysAgo < new Date(tags.timestamp) ? update : '');
+                let name = (tags.name == undefined ? "-" : tags.name) + 
+                    (tags.branch == undefined ? "" : " " + tags.branch) + 
+                    (_7DaysAgo < new Date(tags.timestamp) ? update : '');
                 let category = PoiCont.get_catname(tags);
                 let between = Math.round(PoiCont.calc_between(latlngs[tags.id], map.getCenter()));
                 let target = pois.targets[idx].join(',');


### PR DESCRIPTION
POIに "branch" があれば、nameの後ろ、「更新」ラベルの前に表示するようにしました。
テーブルと詳細ダイアログの両方に対応。